### PR TITLE
Avoid egde cases e.g. wrong masks for odd subnodes + new overlap case

### DIFF
--- a/data/PL_MEM_CM_rev2.yml
+++ b/data/PL_MEM_CM_rev2.yml
@@ -8,7 +8,7 @@ revision: 1
 config:
   - name: firefly
     start: 0
-    count: 40
+    count: 60
     mcu_call: firefly_info
     mcu_extra_call: null
     type: uint16_t
@@ -37,8 +37,9 @@ config:
     postfixes: 
       - Temp_C
       - OptPow
+      - TxDisabled
   - name: uptime
-    start: 44
+    start: 60
     count: 2
     type: uint32_t
     mcu_call: uptime
@@ -47,7 +48,7 @@ config:
     names:
       - MCU_UPTIME
   - name: psmon
-    start: 47
+    start: 62
     count: 84
     mcu_call: psmon
     mcu_extra_call: null
@@ -76,7 +77,7 @@ config:
       - IOUT
       - STATUS_WORD
   - name: gitversion
-    start: 132
+    start: 146
     count: 10
     type: char
     size: 5
@@ -85,7 +86,7 @@ config:
     names:
       - MCU_FW_VER
   - name: adcmon
-    start: 143
+    start: 156
     count: 21
     mcu_call: adcmon
     mcu_extra_call: null
@@ -114,7 +115,7 @@ config:
       - F2_TEMP
       - TM4C_TEMP
   - name: fpga
-    start: 165
+    start: 177
     count: 8
     type: fp16
     extra: Table=CM_MON;Column=Temp_C;Status=2;
@@ -130,7 +131,7 @@ config:
       - F2_TEMP_SLR2
       - F2_TEMP_SLR3
   - name: clkmonr0a
-    start: 174
+    start: 186
     count: 8
     type: uint16_t
     extra: Table=CM_CLK_MON;Status=1
@@ -148,7 +149,7 @@ config:
       - LOSIN_FLG_OR_LOL
       - STICKY_FLG
   - name: clkmon
-    start: 182
+    start: 194
     count: 32
     type: uint16_t
     extra: Table=CM_CLK_MON;Status=1
@@ -169,7 +170,7 @@ config:
       - LOSIN_FLG_OR_LOL
       - STICKY_FLG
   - name: clkr0aconfigversion
-    start: 216
+    start: 228
     count: 4
     type: char
     size: 2
@@ -178,7 +179,7 @@ config:
     names:
       - MCU_CLKR0A_VER
   - name: clkr0bconfigversion
-    start: 220
+    start: 233
     count: 4
     type: char
     size: 2
@@ -187,7 +188,7 @@ config:
     names:
       - MCU_CLKR0B_VER
   - name: clkr1aconfigversion
-    start: 224
+    start: 238
     count: 4
     type: char
     size: 2
@@ -196,7 +197,7 @@ config:
     names:
       - MCU_CLKR1A_VER
   - name: clkr1bconfigversion
-    start: 228
+    start: 243
     count: 4
     type: char
     size: 2
@@ -205,7 +206,7 @@ config:
     names:
       - MCU_CLKR1B_VER
   - name: clkr1cconfigversion
-    start: 232
+    start: 248
     count: 4
     type: char
     size: 2
@@ -214,7 +215,7 @@ config:
     names:
       - MCU_CLKR1C_VER
   - name: firefly_bits
-    start: 236
+    start: 253
     count: 8
     type: uint16_t
     extra: Table=CM_FFARGV_MON;Status=1

--- a/src/xml_generate.py
+++ b/src/xml_generate.py
@@ -166,7 +166,7 @@ for c in config:  # loop over entries in configuration (sensor category)
     start = c['start']
     count = c['count']
     for n in names:  # loop over names of sensors within a category
-        if (n=="R0B" and start!=prev_start+prev_count+1):
+        if (n=="R0B" and start!=prev_start+prev_count+1): #clkmonr0a and clkmon are from the same function in zynqmontask 
             print("warning: the start address of clkmon should continue from clkr0a")
         if 'postfixes' in c:
             postfixes = c['postfixes']
@@ -200,18 +200,16 @@ for c in config:  # loop over entries in configuration (sensor category)
                 prev_bit = bit
                 i += 1
                 j += 1
-                
-                #print("if : n : ", n, " p : ", p, " bit : ", bit)
         else:
             make_node(cm, n, c, start+i, (start+i)%2, "")
             if (prev_bit == (start+i)%2 and prev_addr == int((start+i)/2) and prev_addr != 0) :
                 print("warning : please check if masks overlapped at node ", n, " addr ", hex(prev_addr))
             prev_addr = int((start + i)/2)
             prev_bit = (start+i)%2 
-            #print("else : n : ", n, " bit : ", (start+i)%2)
             i += 1
         prev_start = start
         prev_count = count
+
 tree = ET.ElementTree(cm)
 ET.indent(tree, space='\t')
 #create output file name based on input file, replacing 'yml' with 'xml'


### PR DESCRIPTION
Adjust the XML file script to 
- handle an edge case when the number of subnodes is odd number and the next node should continue to "0xFFFF0000" if the previous data with the same node has 0x0000FFFF masking for 16-bit data. 
- accommodate the overload warning for a V2 packer 
- catch the case when a 32-bit data is sent but its size is actually twice the 16-bit data while size is determined by the number of 16-bit data per node. This seems to be an issue for 32-bit data. Therefore, the arbitrary next starting node needs to be at least twice the size from the previous starting node for 32-bit data